### PR TITLE
[Printing Demo] Add an alternate option to alter PDF page content

### DIFF
--- a/src/DocumentPrinting/DocumentPrinting/Helpers/PrintHelper.Windows.cs
+++ b/src/DocumentPrinting/DocumentPrinting/Helpers/PrintHelper.Windows.cs
@@ -1,4 +1,5 @@
 ﻿#if WINDOWS
+using System.Diagnostics;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.UI.Xaml.Printing;
@@ -51,13 +52,18 @@ public class PrintHelper
         this.sourcePdfDocument = await PdfDocument.LoadFromStreamAsync(ras);
 
         this.pageCount = (int)this.sourcePdfDocument.PageCount;
-        
+
+        // If we have UI thread access, we will use a Canvas
+        // If there is no UI thread access, and exception will be thrown and we instead print without a canvas
         try
         {
+            
             await PrintWithCanvas();
         }
         catch
         {
+            Debug.WriteLine("No UI thread available, printing without Canvas.");
+
             await PrintWithoutCanvas();
         }
     }
@@ -112,22 +118,13 @@ public class PrintHelper
 
             using var pdfPage = this.sourcePdfDocument.GetPage(uint.Parse(i.ToString()));
 
-            var pdfPageSize = pdfPage.Size;
-
-            var width = pdfPageSize.Width;
-            var height = pdfPageSize.Height;
-
-            double pdfPagePreferredZoom = pdfPage.PreferredZoom; //aka 'Scale'
-
             using var ras = new InMemoryRandomAccessStream();
 
-            var pdfPageRenderOptions = new PdfPageRenderOptions
+            await pdfPage.RenderToStreamAsync(ras, new PdfPageRenderOptions
             {
-                DestinationWidth = (uint)(width * pdfPagePreferredZoom),
-                DestinationHeight = (uint)(height * pdfPagePreferredZoom)
-            };
-
-            await pdfPage.RenderToStreamAsync(ras, pdfPageRenderOptions);
+                DestinationWidth = (uint)(pdfPage.Size.Width * pdfPage.PreferredZoom),
+                DestinationHeight = (uint)(pdfPage.Size.Height * pdfPage.PreferredZoom)
+            });
 
             var imageCtrl = new Image();
             var src = new BitmapImage();
@@ -135,9 +132,16 @@ public class PrintHelper
             src.SetSource(ras);
             imageCtrl.Source = src;
 
-            // Using PDF's dimensions for Image control's size
-            imageCtrl.Height = width;
-            imageCtrl.Width = height;
+            // ***** Option 1 ***** //
+            // Use Bitmap's pixel dimensions
+            imageCtrl.Height = src.PixelHeight / DeviceDisplay.Current.MainDisplayInfo.Density; 
+            imageCtrl.Width = src.PixelWidth / DeviceDisplay.Current.MainDisplayInfo.Density; 
+
+            // ***** Option 2 ***** //
+            // Use the PDF's dimensions to size the page contents
+            // Note, this may be smaller, so further tweaking to PdfPageRenderOptions may be needed
+            //imageCtrl.Height = pdfPage.Size.Width;
+            //imageCtrl.Width = pdfPage.Size.Height;
 
             printDocument.AddPage(imageCtrl);
         }
@@ -147,43 +151,47 @@ public class PrintHelper
     {
         for (var i = 0; i < pageCount; i++)
         {
-            using var pdfPage = this.sourcePdfDocument.GetPage((uint)i);
-            var pdfPageSize = pdfPage.Size;
-            var width = pdfPageSize.Width;
-            var height = pdfPageSize.Height;
+            using var pdfPage = this.sourcePdfDocument.GetPage(uint.Parse(i.ToString()));
 
-            var page = new Canvas
+            using var ras = new InMemoryRandomAccessStream();
+
+            await pdfPage.RenderToStreamAsync(ras, new PdfPageRenderOptions
             {
-                Width = width,
-                Height = height,
+                DestinationWidth = (uint)(pdfPage.Size.Width * pdfPage.PreferredZoom),
+                DestinationHeight = (uint)(pdfPage.Size.Height * pdfPage.PreferredZoom)
+            });
+
+            var imageCtrl = new Image();
+            var src = new BitmapImage();
+            ras.Seek(0);
+            src.SetSource(ras);
+            imageCtrl.Source = src;
+
+            // ***** Option 1 ***** //
+            // Use Bitmap's pixel dimensions
+            imageCtrl.Height = src.PixelHeight / DeviceDisplay.Current.MainDisplayInfo.Density; 
+            imageCtrl.Width = src.PixelWidth / DeviceDisplay.Current.MainDisplayInfo.Density; 
+
+            // ***** Option 2 ***** //
+            // Use the PDF's dimensions to size the page contents
+            // Note, this may be smaller, so further tweaking to PdfPageRenderOptions may be needed
+            //imageCtrl.Height = pdfPage.Size.Width;
+            //imageCtrl.Width = pdfPage.Size.Height;
+
+            // Use a canvas behind the image control
+            var pageCanvas = new Canvas
+            {
+                Width = pdfPage.Size.Width,
+                Height = pdfPage.Size.Height,
                 VerticalAlignment = VerticalAlignment.Top,
                 HorizontalAlignment = HorizontalAlignment.Center,
                 Background = new SolidColorBrush(Color.FromArgb(255, 255, 255, 255)),
                 Margin = new Thickness(0, 0, 0, 0)
             };
 
-            double pdfPagePreferredZoom = pdfPage.PreferredZoom; //aka 'Scale'
+            pageCanvas.Children.Add(imageCtrl);
 
-            using var ras = new InMemoryRandomAccessStream();
-
-            var pdfPageRenderOptions = new PdfPageRenderOptions();
-            pdfPageRenderOptions.DestinationHeight = (uint)(height * pdfPagePreferredZoom);
-            pdfPageRenderOptions.DestinationWidth = (uint)(width * pdfPagePreferredZoom);
-
-            await pdfPage.RenderToStreamAsync(ras, pdfPageRenderOptions);
-            ras.Seek(0);
-
-            var imageCtrl = new Image();
-            var src = new BitmapImage();
-            src.SetSource(ras);
-            imageCtrl.Source = src;
-            
-            // Using PDF's dimensions for Image control's size
-            imageCtrl.Height = width;
-            imageCtrl.Width = height;
-
-            page.Children.Add(imageCtrl);
-            pdfDocumentPanel.Children.Add(page);
+            pdfDocumentPanel.Children.Add(pageCanvas);
         }
     }
 

--- a/src/DocumentPrinting/DocumentPrinting/MainPage.xaml.cs
+++ b/src/DocumentPrinting/DocumentPrinting/MainPage.xaml.cs
@@ -12,6 +12,8 @@ public partial class MainPage : ContentPage
 
 	private async void PrintPdf_OnClicked(object sender, EventArgs e)
     {
+        (sender as Button).IsEnabled = false;
+
         var fileName = "pdfviewer-overview.pdf";
         var stream = await FileSystem.OpenAppPackageFileAsync(fileName);
         var helper = new PrintHelper();
@@ -26,6 +28,8 @@ public partial class MainPage : ContentPage
 		helper.Print(stream, fileName);
 
 #endif
+
+        (sender as Button).IsEnabled = true;
     }
 	
 }


### PR DESCRIPTION
This PR addresses #16 where some PDF content may be blurry due to the original content being stretched out after set as the Image's source. There are now two options to set the image's size, with the alternate commented out for future use consideration.